### PR TITLE
Added temporary thumbnail for projects details page

### DIFF
--- a/src/components/details/Details.jsx
+++ b/src/components/details/Details.jsx
@@ -1,5 +1,13 @@
 const Details = () => {
-  return <div>Details</div>;
+  return (
+    <div>
+      <img
+        className="object-cover h-96 w-full "
+        src="/image1.png"
+        alt="Thumbnail for project"
+      ></img>
+    </div>
+  );
 };
 
 export default Details;


### PR DESCRIPTION
Based on the figma and the example image, it seems image was cropped to fit a certain size in the project sections page. Not entirely show if how I did is optimal or correct, so let me know.

This is how the website looks: (fullscreen)
![image](https://github.com/acm-ucr/senior-design-website/assets/146309310/393548f3-86f4-48dd-bf8c-ddc9782301c7)


Not full screen:
![image](https://github.com/acm-ucr/senior-design-website/assets/146309310/c74f6cf8-993d-4e5c-b576-c70aa454c9ed)


