### PR TITLE
Kevinloritsch/addProjectCardstoProjectPage

### DIFF
--- a/src/app/projects/page.js
+++ b/src/app/projects/page.js
@@ -1,11 +1,15 @@
 import Filterbuttons from "../../components/projects/filterbuttons";
+import ProjectCards from "@/components/projects/ProjectCards";
 
 const Page = () => {
   return (
     <>
       <div>Projects</div>
+      <div>
+        <Filterbuttons />
+      </div>
 
-      <Filterbuttons />
+      <ProjectCards />
     </>
   );
 };

--- a/src/components/projects/ProjectCards.jsx
+++ b/src/components/projects/ProjectCards.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import FakeData from "@/data/fakedata";
+import ProjectCard from "@/components/projectcard";
+
+const PastProjects = () => {
+  const numberOfCardsToShow = 18;
+
+  const visibleProjects = FakeData.slice(0, numberOfCardsToShow);
+
+  return (
+    <div className="bg-white  flex justify-center items-center text-center flex-col py-8">
+      <div className="grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 justify-center items-center  gap-14 ">
+        {visibleProjects.map((project, index) => (
+          <ProjectCard key={index} project={project} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PastProjects;

--- a/src/data/fakedata.js
+++ b/src/data/fakedata.js
@@ -13,7 +13,7 @@ const FakeData = [
   {
     projectName: "Name",
     icon: databaselogo,
-    projectType: "Database",
+    projectType: "Embedded Systems",
     year: 2024,
     names: ["Steve", "Sarah"],
     description:
@@ -22,7 +22,7 @@ const FakeData = [
   {
     projectName: "Name",
     icon: databaselogo,
-    projectType: "Database",
+    projectType: "Operating Systems",
     year: 2024,
     names: ["Steve", "Sarah"],
     description:
@@ -31,7 +31,7 @@ const FakeData = [
   {
     projectName: "Name",
     icon: databaselogo,
-    projectType: "Database",
+    projectType: "Electronic Game",
     year: 2024,
     names: ["Steve", "Sarah"],
     description:
@@ -40,7 +40,7 @@ const FakeData = [
   {
     projectName: "Name",
     icon: databaselogo,
-    projectType: "Database",
+    projectType: "Others",
     year: 2024,
     names: ["Steve", "Sarah"],
     description:
@@ -49,7 +49,7 @@ const FakeData = [
   {
     projectName: "Name",
     icon: databaselogo,
-    projectType: "Database",
+    projectType: "Artificial Intelligence",
     year: 2024,
     names: ["Steve", "Sarah"],
     description:
@@ -58,7 +58,7 @@ const FakeData = [
   {
     projectName: "Name",
     icon: databaselogo,
-    projectType: "Database",
+    projectType: "Compiler",
     year: 2024,
     names: ["Steve", "Sarah"],
     description:


### PR DESCRIPTION
![image](https://github.com/acm-ucr/senior-design-website/assets/56408094/958e0d24-2c9e-4726-a7c6-16f784fa18fe)

The code is basically the pastProjects on the index page, except allowing for 18 items (I didn't know if there was a max that you wanted).
I also slightly modified Fake Data to allow for each of the first few icons to have a slightly different type.